### PR TITLE
Renovate ignore npm volta

### DIFF
--- a/npm.json
+++ b/npm.json
@@ -30,6 +30,11 @@
                 "major"
             ],
             "enabled": false
-        }
+        },
+        {
+            "description": "Do not update volta, only for local development not every new node version should be installed",
+            "matchDepTypes": ["volta"],
+            "enabled": false
+          }
     ]
 }


### PR DESCRIPTION
Volta is only local dev dependency, ment mainly if you switch to a older branch with an older node version it uses this version.
If we update this, it will cause a new node install for each new node version, so I would keep this manuall for now.
On CI the node version from the docker image is in charge