### PR TITLE
Update npm renovate config

### DIFF
--- a/npm.json
+++ b/npm.json
@@ -2,8 +2,11 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "description": "Keep dependencies on all active branches up-to-date",
     "extends": [
-        "config:recommended"
+        "config:recommended",
+        "schedule:earlyMondays",
+        ":disableRateLimiting"
     ],
+    "timezone": "Europe/Zurich",
     "baseBranches": [
         "master",
         "release/12.0",


### PR DESCRIPTION
Schedule PR's on early monday
As renovate rate limits the PR creation per hour to max 2, we also need to disable this limit, otherwise it will create only 2 PR each Monday which is too less, e.g. only if we have 3 base branches.