### PR TITLE
renovate 13.1 release branches

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,6 +6,7 @@
     ],
     "baseBranches": [
         "master",
+        "release/13.1",
         "release/12.0",
         "release/10.0"
     ],
@@ -17,8 +18,9 @@
         {
             "description": "Disable major upgrades for release branches",
             "matchBaseBranches": [
-                "release/10.0",
-                "release/12.0"
+                "release/13.1",
+                "release/12.0",
+                "release/10.0"
             ],
             "matchUpdateTypes": [
                 "major"

--- a/npm.json
+++ b/npm.json
@@ -9,6 +9,7 @@
     "timezone": "Europe/Zurich",
     "baseBranches": [
         "master",
+        "release/13.1",
         "release/12.0",
         "release/10.0"
     ],
@@ -27,8 +28,9 @@
         {
             "description": "Disable major upgrades for release branches",
             "matchBaseBranches": [
-                "release/10.0",
-                "release/12.0"
+                "release/13.1",
+                "release/12.0",
+                "release/10.0"
             ],
             "matchUpdateTypes": [
                 "major"


### PR DESCRIPTION
yet this will only affect web-tester and project-build-plugin ... others will follow.