### PR TITLE
Change npm schedule from earlyMondays to weekends

### DIFF
--- a/npm.json
+++ b/npm.json
@@ -3,7 +3,7 @@
     "description": "Keep dependencies on all active branches up-to-date",
     "extends": [
         "config:recommended",
-        "schedule:earlyMondays",
+        "schedule:weekends",
         ":disableRateLimiting"
     ],
     "timezone": "Europe/Zurich",


### PR DESCRIPTION
I noticed that "earlyMondays" means before 4AM, this gives renovate a 4 hour timeslot to do PR's. However, if Renovate does not run in this time frame it will not create any PR for the repo.

So to have the timeframe the whole weekend should "fix" it I think.