### PR TITLE
Do not maintain release/13.1 branch

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,7 +6,6 @@
     ],
     "baseBranches": [
         "master",
-        "release/13.1",
         "release/12.0",
         "release/10.0"
     ],
@@ -18,7 +17,6 @@
         {
             "description": "Disable major upgrades for release branches",
             "matchBaseBranches": [
-                "release/13.1",
                 "release/12.0",
                 "release/10.0"
             ],

--- a/npm.json
+++ b/npm.json
@@ -9,7 +9,6 @@
     "timezone": "Europe/Zurich",
     "baseBranches": [
         "master",
-        "release/13.1",
         "release/12.0",
         "release/10.0"
     ],
@@ -28,7 +27,6 @@
         {
             "description": "Disable major upgrades for release branches",
             "matchBaseBranches": [
-                "release/13.1",
                 "release/12.0",
                 "release/10.0"
             ],


### PR DESCRIPTION
If there are no plans to release/13.1, it makes no sense to maintain these branches for dependency updates. It generates, at least for me, lot of work on my side.