### PR TITLE
Enable `pnpmDedupe` on npm renovate config

### DIFF
--- a/npm.json
+++ b/npm.json
@@ -16,6 +16,7 @@
         "dependencies"
     ],
     "semanticCommits": "disabled",
+    "postUpdateOptions": ["pnpmDedupe"],
     "packageRules": [
         {
             "description": "Do not update own packages",


### PR DESCRIPTION
This should remove duplicated packages from pnpm lock file, if possible