### PR TITLE
Limit node memory

### DIFF
--- a/npm.json
+++ b/npm.json
@@ -17,6 +17,9 @@
     ],
     "semanticCommits": "disabled",
     "postUpdateOptions": ["pnpmDedupe"],
+    "toolSettings": {
+      "nodeMaxMemory": 1024
+    },
     "customManagers": [
         {
             "description": "Update npm global packages in Dockerfile",


### PR DESCRIPTION
Try to limit node memory, as currently renovate runs into out-of-memory exceptions because of pnpm changes?