### PR TITLE
decrease node memory

### DIFF
--- a/npm.json
+++ b/npm.json
@@ -18,7 +18,7 @@
     "semanticCommits": "disabled",
     "postUpdateOptions": ["pnpmDedupe"],
     "toolSettings": {
-      "nodeMaxMemory": 4096
+      "nodeMaxMemory": 2048
     },
     "customManagers": [
         {


### PR DESCRIPTION
Renovate has a 3.0GB container limit.
